### PR TITLE
Update ssl gem version

### DIFF
--- a/adobe_doc_api.gemspec
+++ b/adobe_doc_api.gemspec
@@ -34,5 +34,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday', '~> 1.8'
   spec.add_dependency 'faraday_middleware', '~> 1.2'
   spec.add_dependency 'jwt', '~> 2.3.0'
-  spec.add_dependency 'openssl', '~> 2.2.1'
+  # Updated to allow the latest OpenSSL gem
+  spec.add_dependency 'openssl', '~> 3.1'
 end


### PR DESCRIPTION
## Summary
- bump OpenSSL dependency to allow newer gem versions

## Testing
- `bundle exec rake test` *(fails: could not find compatible versions)*

------
https://chatgpt.com/codex/tasks/task_b_683e12596d2c832388bb30ed98856d9f